### PR TITLE
Now checks for autostart station before presenting switch station window...

### DIFF
--- a/pianobar-notify.sh
+++ b/pianobar-notify.sh
@@ -72,6 +72,7 @@ ip="$fold/isplaying"
 ine="$fold/ignextevent"
 dn="$fold/downloadname"
 dd="$fold/downloaddir"
+st="$fold/state"
 
 while read L; do
     k="`echo "$L" | cut -d '=' -f 1`"
@@ -199,8 +200,9 @@ case "$1" in
 			 echo "$stnum) "$(eval "echo \$station$stnum") >> "$stl"
 		  done
 	   fi
-	   echo "s$($zenity --entry --title="Switch Station" --text="$(cat "$stl")")" > "$ctlf"
-	   ;;
+     if [[ ! `cat "$st" | grep "auto" | cut -d "=" -f 2 | wc -m` -gt 2 ]]; then
+	    echo "$($zenity --entry --title="Switch Station" --text="$(cat "$stl")")" > "$ctlf"
+     fi;;
     
     userlogin)
 	   if [ "$pRet" -ne 1 ]; then


### PR DESCRIPTION
I found out why the switch station window was giving me trouble when I first started pianobar. Pianobar was saving the last station played to "state" in the config folder. So I made the script check to see if there is a value assigned to the variable and if not then it presents the window, if there is a value I don't have it do anything because the user could switch stations if desired.
