### PR TITLE
for the 'fold' var - failback to '/home//.config' if  not set

### DIFF
--- a/control-pianobar.sh
+++ b/control-pianobar.sh
@@ -30,7 +30,7 @@
 #
 # These variables should match YOUR configs
   # Your config folder
-  fold="$XDG_CONFIG_HOME/pianobar"
+  fold="${XDG_CONFIG_HOME:-$HOME/.config}/pianobar"
   # The pianobar executable
   pianobar="pianobar"
   # A blank icon to show when no albumart is found. I prefer to use

--- a/pianobar-notify.sh
+++ b/pianobar-notify.sh
@@ -28,7 +28,7 @@
 # pianobar config file.
 #
 # Also check if this matches you config folder
-fold="$XDG_CONFIG_HOME/pianobar"
+fold="${XDG_CONFIG_HOME:-$HOME/.config}/pianobar"
 
 # You should also place the control-pianobar.sh script in the
 # config folder (or modify the following variable accordingly).


### PR DESCRIPTION
The fix I showed in the issue - in the case I borked the commit message and let it resolve the variable $HOME.  Nonetheless, this updates the only 2 uses of XDG_CONFIG_HOME.