### PR TITLE
Sanitize markup in upcoming songs

### DIFF
--- a/control-pianobar.sh
+++ b/control-pianobar.sh
@@ -186,7 +186,7 @@ upcoming|queue|u)
 	if [[ -n `pidof pianobar` ]]; then
 		echo -n "u" > "$ctlf"
 		sleep .5
-		list="$(grep --text '[0-9])' $logf | sed 's/.*\t [0-9])/*/')"
+		list="$(grep --text '[0-9])' $logf | sed 's/.*\t [0-9])/*/; s/&/\&amp;/; s/</\&lt;/')"
 		if [[ -z "$list" ]]; then
 			$notify "No Upcoming Songs" "This is probably the last song in the list."
 		else


### PR DESCRIPTION
Some notification daemons show blank messages when there's unescaped markup [1]. This only seems to affect the `u` popups. The other ones scrape/parse their info differently and don't seem to be affected.

[1] [Notification Development: If a notification uses a "<" or "&" character](https://wiki.ubuntu.com/NotificationDevelopmentGuidelines#If_a_notification_uses_a_.2BIBw.3C.2BIB0_or_.2BIBw.26.2BIB0_character.2C_and_it_has_missing_or_wrong_text)